### PR TITLE
Updated the link to the Apple Developer Forums

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Third party options
 ###Where can I get good advice?
 
 * [StackOverflow](http://stackoverflow.com/questions/tagged/ios)
-* [Apple Developer Forums](https://devforums.apple.com/index.jspa)
+* [Apple Developer Forums](https://forums.developer.apple.com)
 * [NSHipster](http://nshipster.com)
 * [objc.io](http://objc.io)
 * [Big Nerd Ranch](https://www.bignerdranch.com)


### PR DESCRIPTION
The original link leads to the archived Apple Developer Forums. Updated with a current link.
