### PR TITLE
Updated links to courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Yes.
 
 N.B. These are not websites with individual tutorials, but online courses that you work through 'lesson by lesson'. Some of these may also charge money.
 
-* [Developing iOS 7 apps for iPhone and iPad](https://itunes.apple.com/en/course/developing-ios-7-apps-for/id733644550) by Stanford
-* [Developing iOS 8 apps with Swift by Stanford](https://itunes.apple.com/hk/course/developing-ios-8-apps-swift/id961180099)
+* [Developing iOS 7 Apps for iPhone and iPad](https://itunes.apple.com/us/course/developing-ios-7-apps-for/id733644550) by Stanford (Objective-C)
+* [Developing iOS 9 Apps with Swift](https://itunes.apple.com/ru/course/developing-ios-9-apps-swift/id1104579961) by Stanford (Swift)
 * [Complete iOS 8 and Swift course](https://www.udemy.com/complete-ios-developer-course/) by Udemy
 * [iOS tutorials on Lynda](http://www.lynda.com/iOS-training-tutorials/413-0.html)
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Yes.
 N.B. These are not websites with individual tutorials, but online courses that you work through 'lesson by lesson'. Some of these may also charge money.
 
 * [Developing iOS 7 Apps for iPhone and iPad](https://itunes.apple.com/us/course/developing-ios-7-apps-for/id733644550) by Stanford (Objective-C)
-* [Developing iOS 9 Apps with Swift](https://itunes.apple.com/ru/course/developing-ios-9-apps-swift/id1104579961) by Stanford (Swift)
+* [Developing iOS 9 Apps with Swift](https://itunes.apple.com/us/course/developing-ios-9-apps-swift/id1104579961) by Stanford (Swift)
 * [Complete iOS 8 and Swift course](https://www.udemy.com/complete-ios-developer-course/) by Udemy
 * [iOS tutorials on Lynda](http://www.lynda.com/iOS-training-tutorials/413-0.html)
 


### PR DESCRIPTION
Fix broken link to iOS 7 Stanford course.
Also update Stanford Swift course link to latest version.
