### PR TITLE
Add Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@
 
 # iOS Programming FAQ
 
+## Table of Contents
+
+* [Basics](#basics)
+* [Prerequisites](#prerequisites)
+* [Tools](#tools)
+* [SDK](#sdk)
+* [Common Tasks](#common-tasks)
+* [Language](#language)
+* [Cloud and Web](#cloud-and-web)
+* [Design](#design)
+* [Community](#community)
+* [Third Party Code](#third-party-code)
+* [The App Store](#the-app-store)
+* [Contracting and Employment](#contracting-and-employment)
+
 ## Basics
 
 The most valuable source of information available to iOS Developers is [Apple's Developer Library](https://developer.apple.com/library/ios/navigation/). This contains thousands of documents explaining every single function in the SDK, hundreds of sample applications and several years of WWDC videos. If you've got a problem, this should always be the first place that you should look.


### PR DESCRIPTION
Add a table of contents that lets people navigate to different areas of the FAQ. I created a TOC listing for every Heading 2 section in the FAQ.