### PR TITLE
Add Table of Contents to README-Swift

### DIFF
--- a/README-Swift.md
+++ b/README-Swift.md
@@ -8,6 +8,21 @@
 
 # iOS Programming FAQ
 
+## Table of Contents
+
+* [Basics](#basics)
+* [Prerequisites](#prerequisites)
+* [Tools](#tools)
+* [SDK](#sdk)
+* [Common Tasks](#common-tasks)
+* [Language](#language)
+* [Cloud and Web](#cloud-and-web)
+* [Design](#design)
+* [Community](#community)
+* [Third Party Code](#third-party-code)
+* [The App Store](#the-app-store)
+* [Contracting and Employment](#contracting-and-employment)
+
 ## Basics
 
 The most valuable source of information available to iOS Developers is [Apple's Developer Library](https://developer.apple.com/library/ios/navigation/). This contains thousands of documents explaining every single function in the SDK, hundreds of sample applications and several years of WWDC videos. If you've got a problem, this should always be the first place that you should look.


### PR DESCRIPTION
Adding a table of contents to the README-Swift file to make navigating the FAQ easier. There is a TOC entry for each Heading 2 section in the FAQ.